### PR TITLE
Consider results outside of :var blocks

### DIFF
--- a/test-report/test/test_report/summary_test.clj
+++ b/test-report/test/test_report/summary_test.clj
@@ -9,6 +9,8 @@
 (intern 'example.first-test 'erroring (fn []))
 (create-ns 'example.second-test)
 (intern 'example.second-test 'passing (fn []))
+(create-ns 'example.empty-since-fixture-failed-test)
+(intern 'example.empty-since-fixture-failed-test 'erroring (fn []))
 
 (deftest summarize-messages
   (let [messages [{:type :begin-test-ns
@@ -71,11 +73,20 @@
                   {:type :end-test-ns
                    :ns (find-ns 'example.second-test)
                    :time 116894654251062}
+                  {:type :begin-test-ns
+                   :ns (find-ns 'example.empty-since-fixture-failed-test)
+                   :time 116894653100547}
+                  {:type :error
+                   :message "smth"
+                   :time 116894653734493}
+                  {:type :end-test-ns
+                   :ns (find-ns 'example.empty-since-fixture-failed-test)
+                   :time 116894654251062}
                   {:type :summary
                    :test 5
                    :pass 4
                    :fail 1
-                   :error 1
+                   :error 2
                    :time 116894654397872}]]
     (is (= {:namespaces [{:ns (find-ns 'example.first-test)
                           :time 25712629
@@ -106,10 +117,18 @@
                                     :assertion 1
                                     :pass 1
                                     :fail 0
-                                    :error 0}}]
-            :summary {:test 5
-                      :assertion 6
+                                    :error 0}}
+                         {:ns (find-ns 'example.empty-since-fixture-failed-test)
+                          :time 1150515
+                          :tests [{:results [{:message "smth" :type :error}]}]
+                          :summary {:test 1
+                                    :assertion 1
+                                    :pass 0
+                                    :fail 0
+                                    :error 1}}]
+            :summary {:test 6
+                      :assertion 7
                       :pass 4
                       :fail 1
-                      :error 1}}
+                      :error 2}}
            (summarize messages)))))


### PR DESCRIPTION
It's possible to be results outside of `:begin-test-var`/`:end-test-var`, for example of `:error` type in case of exception in a test fixture. Currently such results are ignored.

How to reproduce:

```clojure
$ cat test/test_report/str.clj
(ns test-report.str
  (:require [clojure.test :refer [deftest is use-fixtures]]
            [test-report.summary :refer [summarize]]
            [test-report.core :refer [activate]]
            [clojure.pprint :refer [pprint]]))

(activate {:summarizers [(comp pprint summarize)]})
(use-fixtures :each (fn [f] (/ 1 0) (f)))
(deftest will-never-ran (is true))

$ lein test :only test-report.str

Testing test-report.str

ERROR in (test-report.str) (Numbers.java:158)
Uncaught exception in test fixture
expected: nil
  actual: java.lang.ArithmeticException: Divide by zero
 at clojure.lang.Numbers.divide (Numbers.java:158)
    clojure.lang.Numbers.divide (Numbers.java:3808)
    test_report.str$eval413$fn__414.invoke (str.clj:8)
    clojure.test$compose_fixtures$fn__7977$fn__7978.invoke (test.clj:693)
    clojure.test$default_fixture.invokeStatic (test.clj:686)
    clojure.test$default_fixture.invoke (test.clj:682)
    clojure.test$compose_fixtures$fn__7977.invoke (test.clj:693)
    clojure.test$test_vars$fn__8005.invoke (test.clj:734)
    clojure.test$default_fixture.invokeStatic (test.clj:686)
    clojure.test$default_fixture.invoke (test.clj:682)
    clojure.test$test_vars.invokeStatic (test.clj:730)
    clojure.test$test_all_vars.invokeStatic (test.clj:736)
    clojure.test$test_ns.invokeStatic (test.clj:757)
    clojure.test$test_ns.invoke (test.clj:742)
    user$eval85$fn__196.invoke (form-init1833884939756857322.clj:1)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.injected$compose_hooks$fn__19.doInvoke (form-init1833884939756857322.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.injected$run_hooks.invokeStatic (form-init1833884939756857322.clj:1)
    leiningen.core.injected$run_hooks.invoke (form-init1833884939756857322.clj:1)
    leiningen.core.injected$prepare_for_hooks$fn__24$fn__25.doInvoke (form-init1833884939756857322.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$map$fn__4785.invoke (core.clj:2646)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1749)
    clojure.lang.RestFn.applyTo (RestFn.java:130)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.test$run_tests.invokeStatic (test.clj:767)
    clojure.test$run_tests.doInvoke (test.clj:767)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$apply.invoke (core.clj:641)
    test_report.core$collect_messages.invokeStatic (core.clj:37)
    test_report.core$collect_messages.doInvoke (core.clj:34)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$apply.invoke (core.clj:641)
    test_report.core$activate$fn__399$fn__403.invoke (core.clj:55)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$with_bindings_STAR_.invokeStatic (core.clj:1881)
    clojure.core$with_bindings_STAR_.doInvoke (core.clj:1881)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    test_report.core$activate$fn__399.doInvoke (core.clj:55)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    robert.hooke$compose_hooks$fn__295.doInvoke (hooke.clj:40)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$apply.invoke (core.clj:641)
    robert.hooke$run_hooks.invokeStatic (hooke.clj:46)
    robert.hooke$run_hooks.invoke (hooke.clj:45)
    robert.hooke$prepare_for_hooks$fn__300$fn__301.doInvoke (hooke.clj:54)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.core$apply.invoke (core.clj:641)
    user$eval85$fn__208$fn__259.invoke (form-init1833884939756857322.clj:1)
    user$eval85$fn__208$fn__209.invoke (form-init1833884939756857322.clj:1)
    user$eval85$fn__208.invoke (form-init1833884939756857322.clj:1)
    user$eval85.invokeStatic (form-init1833884939756857322.clj:1)
    user$eval85.invoke (form-init1833884939756857322.clj:1)
    clojure.lang.Compiler.eval (Compiler.java:6927)
    clojure.lang.Compiler.eval (Compiler.java:6917)
    clojure.lang.Compiler.load (Compiler.java:7379)
    clojure.lang.Compiler.loadFile (Compiler.java:7317)
    clojure.main$load_script.invokeStatic (main.clj:275)
    clojure.main$init_opt.invokeStatic (main.clj:277)
    clojure.main$init_opt.invoke (main.clj:277)
    clojure.main$initialize.invokeStatic (main.clj:308)
    clojure.main$null_opt.invokeStatic (main.clj:342)
    clojure.main$null_opt.invoke (main.clj:339)
    clojure.main$main.invokeStatic (main.clj:421)
    clojure.main$main.doInvoke (main.clj:384)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)

Ran 0 tests containing 1 assertions.
0 failures, 1 errors.
{:namespaces
 [{:ns #object[clojure.lang.Namespace 0x45815ffc "test-report.str"],
   :time 44671979,
   :tests [],
   :summary {:test 0, :assertion 0, :fail 0, :error 0, :pass 0}}],
 :summary {:test 0, :assertion 0, :fail 0, :error 0, :pass 0}}
Tests failed.
```

it should be at list with right statistic: 
```clojure
{:namespaces
 [{:ns #object[clojure.lang.Namespace 0x45815ffc "test-report.str"],
   :time 44671979,
   :tests [],
   :summary {:test 1, :assertion 1, :fail 0, :error 1, :pass 0}}],
 :summary {:test 1, :assertion 1, :fail 0, :error 1, :pass 0}}
```

even maybe it worth to pass such results into `:tests` of `:namespaces` (with only `:results` key):
```clojure
{:namespaces
 [{:ns #object[clojure.lang.Namespace 0x45815ffc "test-report.str"],
   :time 44671979,
   :tests 
   [{:results
     [{:file "Numbers.java",
       :line 158,
       :type :error,
       :expected nil,
       :actual #error { ... }
       :message "Uncaught exception in test fixture",
       :context ()}]}],
   :summary {:test 1, :assertion 1, :fail 0, :error 1, :pass 0}}],
 :summary {:test 1, :assertion 1, :fail 0, :error 1, :pass 0}}
```
